### PR TITLE
New database migration strategy

### DIFF
--- a/disciple-tools.php
+++ b/disciple-tools.php
@@ -252,6 +252,7 @@ class Disciple_Tools {
          */
         $this->token            = 'disciple_tools';
         $this->version          = '0.1';
+        $this->migration_number = 0;
         $this->plugin_url       = plugin_dir_url( __FILE__ );
         $this->plugin_path      = plugin_dir_path( __FILE__ );
         $this->plugin_img_url   = plugin_dir_url( __FILE__ ) . 'dt-core/admin/img/';

--- a/dt-core/admin/class-activator.php
+++ b/dt-core/admin/class-activator.php
@@ -65,6 +65,9 @@ class Disciple_Tools_Activator {
         } else {
             Disciple_Tools_Migration_Engine::migrate( Disciple_Tools()->migration_number );
         }
+
+        // TODO: we need to run the migrations on updates as well, not just on
+        // activations
     }
 
     /**

--- a/dt-core/admin/class-activator.php
+++ b/dt-core/admin/class-activator.php
@@ -10,10 +10,12 @@
  * @author
  */
 
+require_once( dirname( __FILE__ ) . '/class-migration-engine.php' );
+
 
 class Disciple_Tools_Activator {
-    
-    
+
+
     /**
      * Activities to run during installation.
      *
@@ -23,13 +25,13 @@ class Disciple_Tools_Activator {
         global $wpdb;
         $Disciple_Tools = Disciple_Tools();
         $Disciple_Tools->_log_version_number();
-        
+
         /** Create roles and capabilities */
         require_once( 'class-roles.php' );
         $roles = Disciple_Tools_Roles::instance();
         $roles->set_roles();
-        
-        
+
+
         /** Setup key for JWT authentication */
         if ( ! defined( 'JWT_AUTH_SECRET_KEY' ) ) {
             if ( get_option( "my_jwt_key" ) ) {
@@ -40,7 +42,7 @@ class Disciple_Tools_Activator {
                 define( 'JWT_AUTH_SECRET_KEY', $iv );
             }
         }
-        
+
         /** Add default dt site options for ini*/
         $site_options = dt_get_site_options_defaults();
         if ( ! get_option( 'dt_site_options' ) ) { // create new if it doesn't exist
@@ -49,22 +51,22 @@ class Disciple_Tools_Activator {
             dt_update_site_options_to_current_version();
         }
         dt_add_site_custom_lists(); // setup options for site_custom_lists
-        
-        
+
+
         /** Activate database creation for Disciple Tools Activity logs */
         if ( is_multisite() && $network_wide ) {
             // Get all blogs in the network and activate plugin on each one
             $blog_ids = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
             foreach ( $blog_ids as $blog_id ) {
                 switch_to_blog( $blog_id );
-                self::create_tables( $Disciple_Tools->version );
+                Disciple_Tools_Migration_Engine::migrate( Disciple_Tools()->migration_number );
                 restore_current_blog();
             }
         } else {
-            self::create_tables( $Disciple_Tools->version );
+            Disciple_Tools_Migration_Engine::migrate( Disciple_Tools()->migration_number );
         }
     }
-    
+
     /**
      * Creating tables whenever a new blog is created
      *
@@ -76,124 +78,22 @@ class Disciple_Tools_Activator {
      * @param $meta
      */
     public static function on_create_blog( $blog_id, $user_id, $domain, $path, $site_id, $meta ) {
-        
+
         if ( is_plugin_active_for_network( 'disciple-tools/disciple-tools.php' ) ) {
             switch_to_blog( $blog_id );
-            self::create_tables( Disciple_Tools()->version );
+            Disciple_Tools_Migration_Engine::migrate( Disciple_Tools()->migration_number );
             restore_current_blog();
         }
-        
+
     }
-    
+
     public static function on_delete_blog( $tables ) {
         global $wpdb;
         $tables[] = $wpdb->prefix . 'dt_activity_log';
         $tables[] = $wpdb->prefix . 'dt_reports';
         $tables[] = $wpdb->prefix . 'dt_reportmeta';
-        
+
         return $tables;
     }
-    
-    /**
-     * Creates the tables for the activity and report logs.
-     *
-     * @access protected
-     */
-    protected static function create_tables( $version ) {
-        global $wpdb;
-        $charset_collate = $wpdb->get_charset_collate();
-        
-        require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
-        
-        /* Activity Log */
-        $table_name = $wpdb->prefix . 'dt_activity_log';
-        if ( $wpdb->get_var( "show tables like '{$table_name}'" ) != $table_name ) {
-            $sql1 = "CREATE TABLE IF NOT EXISTS `{$table_name}` (
-					  `histid` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-					  `user_caps` varchar(70) NOT NULL DEFAULT 'guest',
-					  `action` varchar(255) NOT NULL,
-					  `object_type` varchar(255) NOT NULL,
-					  `object_subtype` varchar(255) NOT NULL DEFAULT '',
-					  `object_name` varchar(255) NOT NULL,
-					  `object_id` int(11) NOT NULL DEFAULT '0',
-					  `user_id` int(11) NOT NULL DEFAULT '0',
-					  `hist_ip` varchar(55) NOT NULL DEFAULT '127.0.0.1',
-					  `hist_time` int(11) NOT NULL DEFAULT '0',
-					  `object_note` VARCHAR(255) NOT NULL DEFAULT '0',
-					  `meta_id` BIGINT(20) NOT NULL DEFAULT '0',
-					  `meta_key` VARCHAR(100) NOT NULL DEFAULT '0',
-					  `meta_value` VARCHAR(255) NOT NULL DEFAULT '0',
-					  `meta_parent` BIGINT(20) NOT NULL DEFAULT '0',
-					  PRIMARY KEY (`histid`)
-				) $charset_collate;";
-            
-            dbDelta( $sql1 );
-            
-            update_option( 'dt_activity_log_db_version', $version );
-        }
-        
-        /* Report Log Table */
-        $table_name = $wpdb->prefix . 'dt_reports';
-        if ( $wpdb->get_var( "show tables like '{$table_name}'" ) != $table_name ) {
-            $sql2 = "CREATE TABLE IF NOT EXISTS `{$table_name}` (
-					  `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
-					  `report_date` DATE NOT NULL,
-					  `report_source` VARCHAR(55) NOT NULL,
-					  `report_subsource` VARCHAR(100) NOT NULL,
-					  PRIMARY KEY (`id`)
-				) $charset_collate;";
-            dbDelta( $sql2 );
-            update_option( 'dt_reports_db_version', $version );
-        }
-        
-        /* Report Meta Log Table */
-        $table_name = $wpdb->prefix . 'dt_reportmeta';
-        if ( $wpdb->get_var( "show tables like '{$table_name}'" ) != $table_name ) {
-            $sql3 = "CREATE TABLE IF NOT EXISTS `{$table_name}` (
-					  `meta_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-					  `report_id` BIGINT(20) UNSIGNED NOT NULL DEFAULT '0',
-					  `meta_key` VARCHAR(255) NOT NULL,
-					  `meta_value` LONGTEXT,
-					  PRIMARY KEY (`meta_id`)
-				) $charset_collate;";
-            dbDelta( $sql3 );
-            update_option( 'dt_reportmeta_db_version', $version );
-        }
-        
-        /* Report Meta Log Table */
-        $table_name = $wpdb->prefix . 'dt_share';
-        if ( $wpdb->get_var( "show tables like '{$table_name}'" ) != $table_name ) {
-            $sql4 = "CREATE TABLE IF NOT EXISTS `{$table_name}` (
-					  `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-					  `user_id` BIGINT(20) UNSIGNED NOT NULL DEFAULT '0',
-					  `post_id` BIGINT(20) UNSIGNED NOT NULL DEFAULT '0',
-					  `meta` LONGTEXT,
-					  PRIMARY KEY (`id`)
-				) $charset_collate;";
-            dbDelta( $sql4 );
-            update_option( 'dt_share_db_version', $version );
-        }
-        
-        /* Notifications Table */
-        $table_name = $wpdb->prefix . 'dt_notifications';
-        if ( $wpdb->get_var( "show tables like '{$table_name}'" ) != $table_name ) {
-            $sql5 = "CREATE TABLE IF NOT EXISTS `{$table_name}` (
-                      `id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-                      `user_id` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
-                      `source_user_id` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
-                      `post_id` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
-                      `secondary_item_id` bigint(20) DEFAULT NULL,
-                      `notification_name` varchar(75) NOT NULL DEFAULT '0',
-                      `notification_action` varchar(75) NOT NULL DEFAULT '0',
-                      `notification_note` varchar(255) DEFAULT NULL,
-                      `date_notified` DATETIME NOT NULL,
-                      `is_new` tinyint(1) UNSIGNED NOT NULL DEFAULT '1',
-                      PRIMARY KEY (`id`)
-				) $charset_collate;";
-            dbDelta( $sql5 );
-            update_option( 'dt_notifications_db_version', $version );
-        }
-        
-    }
-    
+
 }

--- a/dt-core/admin/class-deactivator.php
+++ b/dt-core/admin/class-deactivator.php
@@ -44,17 +44,16 @@ class Disciple_Tools_Deactivator {
     protected static function _remove_tables() {
         global $wpdb;
 
+        // TODO: replace this code, with running migrations backwards
+
         $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}dt_activity_log`;" );
         $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}dt_reports`;" );
         $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}dt_reportmeta`;" );
         $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}dt_share`;" );
         $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}dt_notifications`;" );
 
-        delete_option( 'dt_activity_log_db_version' );
-        delete_option( 'dt_reports_db_version' );
-        delete_option( 'dt_reportmeta_db_version' );
-        delete_option( 'dt_share_db_version' );
-        delete_option( 'dt_notifications_db_version' );
+        delete_option( 'dt_migration_number' );
+
     }
 
 

--- a/dt-core/admin/class-migration-engine.php
+++ b/dt-core/admin/class-migration-engine.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
+
+/**
+ * For more documentation, see the class Disciple_Tools_Migration in file
+ * migrations/abstract.php
+ *
+ */
+
+class Disciple_Tools_Migration_Engine {
+    protected static $migrations = null;
+
+    protected static function get_migrations(): array {
+
+        if (self::$migrations !== null) {
+            return self::$migrations;
+        }
+        require_once( dirname( __FILE__ ) . "/../../migrations/abstract.php" );
+        $filenames = scandir( dirname( __FILE__ ) . "/../../migrations/", SCANDIR_SORT_ASCENDING );
+        if ( $filenames === false ) {
+            throw new Exception( "Could not scan migrations directory" );
+        }
+        $expected_migration_number = 0;
+        $rv = array();
+        foreach ( $filenames as $filename ) {
+            if ( $filename[0] === "." || $filename === "abstract.php" ) {
+                // skip this filename
+            } else if ( preg_match( '/^([0-9][0-9][0-9][0-9])(-.*)?\.php$/i', $filename, $matches ) ) {
+                $got_migration_number = intval( $matches[1] );
+                if ( $expected_migration_number !== $got_migration_number ) {
+                    throw new Exception( sprintf( "Expected to find migration number %04d", $expected_migration_number ) );
+                }
+                require_once( dirname( __FILE__ ) . "/../../migrations/$filename" );
+                $migration_name = sprintf( "Disciple_Tools_Migration_%04d", $got_migration_number );
+                $rv[] = new $migration_name();
+                $expected_migration_number++;
+            } else {
+                throw new Exception( "Found filename that doesn't match pattern: $filename" );
+            }
+        }
+        self::$migrations = $rv;
+        return self::$migrations;
+
+    }
+
+    /**
+     * Migrate the database to the passed target migration number. If it is
+     * already reached, do nothing.
+     *
+     * @return void
+     */
+    public static function migrate( int $target_migration_number ) {
+        if ( $target_migration_number >= count( self::get_migrations() ) ) {
+            throw new Exception( "Migration number $target_migration_number does not exist" );
+        }
+
+        while (true) {
+            $current_migration_number = get_option( 'dt_migration_number' );
+            if ( $current_migration_number === false ) {
+                $current_migration_number = -1;
+            }
+            if (! preg_match( '/^-?[0-9]+$/', (string) $current_migration_number ) ) {
+                throw new Exception( "Current migration number doesn't look like an integer ($current_migration_number)" );
+            }
+            $current_migration_number = intval( $current_migration_number );
+
+            if ( $target_migration_number === $current_migration_number ) {
+                break;
+            } else if ( $target_migration_number < $current_migration_number ) {
+                throw new Exception( "Trying to migrate backwards, aborting" );
+            }
+
+            $activating_migration_number = $current_migration_number + 1;
+            $migration = self::get_migrations()[$activating_migration_number];
+
+            self::sanity_check_expected_tables( $migration->get_expected_tables() );
+
+            if ( (int) get_option( 'dt_migration_lock', 0 ) ) {
+                throw new Exception( "Cannot migrate, as migration lock is held" );
+            }
+            update_option( 'dt_migration_lock', '1' );
+
+            error_log( date( " Y-m-d H:i:s T" ) . " Starting migrating to number $activating_migration_number" );
+            $migration->up();
+            update_option( 'dt_migration_number', (string) $activating_migration_number );
+            error_log( date( " Y-m-d H:i:s T" ) . " Done migrating to number $activating_migration_number" );
+
+            update_option( 'dt_migration_lock', '0' );
+
+            $migration->test();
+
+        }
+    }
+
+    protected static function sanity_check_expected_tables( array $expected_tables ) {
+        global $wpdb;
+        foreach ( $expected_tables as $name => $table ) {
+            if ( preg_match( '/\bIF NOT EXISTS\b/i', $table ) ) {
+                throw new Exception( "Table definition of $name should not contain 'IF NOT EXISTS'" );
+            } elseif ( ! preg_match( '/\b' . preg_quote( $name ) . '\b/', $table ) ) {
+                throw new Exception( "Expected to find table name in table definition of $name" );
+            } elseif ( strpos( $name, $wpdb->prefix ) !== 0 ) {
+                throw new Exception( "Table name expected to start with prefix {$wpdb->prefix}" );
+            }
+        }
+    }
+
+}
+
+

--- a/dt-core/logging/class-activity-log-db.php
+++ b/dt-core/logging/class-activity-log-db.php
@@ -88,9 +88,6 @@ class Disciple_Tools_Activity_Log_DB {
         dbDelta( $sql2 );
         dbDelta( $sql3 );
 
-        update_option( 'dt_activity_log_db_version', '1.0' );
-        update_option( 'dt_reports_db_version', '1.0' );
-        update_option( 'dt_reportmeta_db_version', '1.0' );
 
     }
 
@@ -106,8 +103,5 @@ class Disciple_Tools_Activity_Log_DB {
         $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}dt_reports`;" );
         $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}dt_reportmeta`;" );
 
-        delete_option( 'dt_activity_log_db_version' );
-        delete_option( 'dt_reports_db_version' );
-        delete_option( 'dt_reportmeta_db_version' );
     }
 }

--- a/migrations/0000-initial.php
+++ b/migrations/0000-initial.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+require_once( 'abstract.php' );
+
+class Disciple_Tools_Migration_0000 extends Disciple_Tools_Migration {
+
+    public function up() {
+        global $wpdb;
+        $expected_tables = $this->get_expected_tables();
+        foreach ( $expected_tables as $name => $table) {
+            $rv = $wpdb->query( $table ); // WPCS: unprepared SQL OK
+            if ( $rv == false ) {
+                throw new Exception( "Got error when creating table $name: $wpdb->last_error" );
+            }
+        }
+    }
+
+    public function down() {
+        global $wpdb;
+        foreach ( $expected_tables as $name => $table) {
+            $rv = $wpdb->query( "DROP TABLE `{$name}`" ); // WPCS: unprepared SQL OK
+            if ( $rv == false ) {
+                throw new Exception( "Got error when dropping table $name: $wpdb->last_error" );
+            }
+        }
+    }
+
+    public function get_expected_tables(): array {
+        global $wpdb;
+        $charset_collate = $wpdb->get_charset_collate();
+        return array(
+            "{$wpdb->prefix}dt_activity_log" =>
+                "CREATE TABLE `{$wpdb->prefix}dt_activity_log` (
+                    `histid` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+                    `user_caps` varchar(70) NOT NULL DEFAULT 'guest',
+                    `action` varchar(255) NOT NULL,
+                    `object_type` varchar(255) NOT NULL,
+                    `object_subtype` varchar(255) NOT NULL DEFAULT '',
+                    `object_name` varchar(255) NOT NULL,
+                    `object_id` int(11) NOT NULL DEFAULT '0',
+                    `user_id` int(11) NOT NULL DEFAULT '0',
+                    `hist_ip` varchar(55) NOT NULL DEFAULT '127.0.0.1',
+                    `hist_time` int(11) NOT NULL DEFAULT '0',
+                    `object_note` VARCHAR(255) NOT NULL DEFAULT '0',
+                    `meta_id` BIGINT(20) NOT NULL DEFAULT '0',
+                    `meta_key` VARCHAR(100) NOT NULL DEFAULT '0',
+                    `meta_value` VARCHAR(255) NOT NULL DEFAULT '0',
+                    `meta_parent` BIGINT(20) NOT NULL DEFAULT '0',
+                    PRIMARY KEY (`histid`)
+                ) $charset_collate;",
+            "{$wpdb->prefix}dt_reports" =>
+                "CREATE TABLE `{$wpdb->prefix}dt_reports` (
+                    `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+                    `report_date` DATE NOT NULL,
+                    `report_source` VARCHAR(55) NOT NULL,
+                    `report_subsource` VARCHAR(100) NOT NULL,
+                    PRIMARY KEY (`id`)
+            ) $charset_collate;",
+            "{$wpdb->prefix}dt_reportmeta" =>
+                "CREATE TABLE `{$wpdb->prefix}dt_reportmeta` (
+                    `meta_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+                    `report_id` BIGINT(20) UNSIGNED NOT NULL DEFAULT '0',
+                    `meta_key` VARCHAR(255) NOT NULL,
+                    `meta_value` LONGTEXT,
+                    PRIMARY KEY (`meta_id`)
+            ) $charset_collate;",
+            "{$wpdb->prefix}dt_share" =>
+                "CREATE TABLE `{$wpdb->prefix}dt_share` (
+                    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+                    `user_id` BIGINT(20) UNSIGNED NOT NULL DEFAULT '0',
+                    `post_id` BIGINT(20) UNSIGNED NOT NULL DEFAULT '0',
+                    `meta` LONGTEXT,
+                    PRIMARY KEY (`id`)
+            ) $charset_collate;",
+            "{$wpdb->prefix}dt_notifications" =>
+                "CREATE TABLE `{$wpdb->prefix}dt_notifications` (
+                    `id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+                    `user_id` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
+                    `source_user_id` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
+                    `post_id` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
+                    `secondary_item_id` bigint(20) DEFAULT NULL,
+                    `notification_name` varchar(75) NOT NULL DEFAULT '0',
+                    `notification_action` varchar(75) NOT NULL DEFAULT '0',
+                    `notification_note` varchar(255) DEFAULT NULL,
+                    `date_notified` DATETIME NOT NULL,
+                    `is_new` tinyint(1) UNSIGNED NOT NULL DEFAULT '1',
+                    PRIMARY KEY (`id`)
+            ) $charset_collate;",
+        );
+    }
+
+
+    public function test() {
+        $this->test_expected_tables();
+    }
+
+}

--- a/migrations/abstract.php
+++ b/migrations/abstract.php
@@ -1,0 +1,123 @@
+<?php
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
+
+/**
+ * The abstract class that represents one migration.
+ *
+ * Our migration strategy is inspired by Phinx, Laravel and Django:
+ *
+ * - https://phinx.org/
+ * PHP database migration library
+ *
+ * - https://laravel.com/docs/5.5/migrations
+ * PHP framework which includes database migrations
+ *
+ * - https://docs.djangoproject.com/en/stable/topics/migrations/
+ * Python framework which includes database migrations
+ *
+ * Migrations should be placed in this directory, with names like this:
+ *
+ *      0000-initial.php
+ *      0001-add-table-photos.php
+ *      0002-alter-photos-table.php
+ *      0003.php
+ *
+ *  The names must begin with four digits, and they must be in order with no
+ *  gaps, starting at 0000. Each file must contain a migration class named
+ *  "Disciple_Tools_Migration_xxxx", where xxxx is the migration number. For
+ *  example:
+ *
+ *      class Disciple_Tools_Migration_0002 extends Disciple_Tools_Migration {
+ *          // ...
+ *      }
+ *
+ *  See the documentation for Disciple_Tools_Migration_Engine.
+ *
+ */
+abstract class Disciple_Tools_Migration {
+
+    /**
+     * Migrate up to this migration version. Override this method and add code
+     * that creates or updates tables as needed.
+     *
+     * @return void
+     */
+    abstract public function up();
+
+    /**
+     * Migrate down, that is, undo this migration. This should reverse whatever
+     * the method `up` does.
+     *
+     * @return void
+     */
+    abstract public function down();
+
+    /**
+     * Test that this migration has been applied. Override this method and add
+     * code that checks that the tables that have been modified are in the
+     * correct state. This code may be called before and after migrations. This
+     * method should throw an exception to indicate a test failure.
+     *
+     * We recommend using the utility method test_expected_tables here.
+     *
+     * @return void
+     */
+    abstract public function test();
+
+    /**
+     * Return an array mapping table names to table definitions. For example:
+     *
+     *      array(
+     *          "{$wpdb->prefix}example" => "CREATE TABLE `{$wpdb->prefix}` (`id` INT NOT NULL);",
+     *      );
+     *
+     *  It is recommended to use this function, as the database migration may
+     *  use it to run some sanity checks for you automatically.
+     *
+     *  @return array
+     */
+    public function get_expected_tables(): array {
+        return array();
+    }
+
+    /**
+     * @return void
+     */
+    protected function test_expected_tables() {
+        global $wpdb;
+        $expected_tables = $this->get_expected_tables();
+        foreach ( $expected_tables as $name => $expected_table ) {
+            $got_table = $wpdb->get_var( "SHOW CREATE TABLE `$name`", 1, 0 ); // WPCS: unprepared SQL OK
+            $got_table = self::clean_create_query( $got_table );
+            $expected_table = self::clean_create_query( $expected_table );
+            if ( $got_table !== $expected_table ) {
+                error_log( "Got: $got_table\n\nExpected:\n\n$expected_table\n\n" );
+                throw new DT_Migration_Test_Exception( "Table $name not as expected, see error log" );
+            }
+        }
+    }
+
+    /**
+     * Private function that is used to delete some information from "CREATE
+     * TABLE" queries, to make them easier to compare.
+     */
+    private static function clean_create_query( string $table_definition ): string {
+        $rv = preg_replace( '/^\s*/m', '', strtolower( $table_definition ) );
+        $rv = preg_replace( '/\s*$/m', '', $rv );
+        $rv = preg_replace( '/\bcollate [^\s]+\b/i', '', $rv );
+        $rv = preg_replace( '/\bcollate=[^\s]+\b/i', '', $rv );
+        $rv = preg_replace( '/\bengine=innodb\b/', '', $rv );
+        $rv = preg_replace( '/\bdefault character set\s/', 'default charset=', $rv );
+        $rv = preg_replace( '/\s+,/', ',', $rv );
+        $rv = preg_replace( '/;$/', '', $rv );
+        $rv = preg_replace( '/\s\s+/', ' ', $rv );
+        return $rv;
+    }
+
+
+}
+
+class DT_Migration_Test_Exception extends Exception {
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -155,6 +155,8 @@
     <exclude name="WordPress.Arrays.CommaAfterArrayItem.SpaceAfterComma" />
     <exclude name="WordPress.Arrays.CommaAfterArrayItem.SpaceBeforeComma" />
     <exclude name="WordPress.PHP.YodaConditions.NotYoda" />
+    <exclude name="WordPress.VIP.DirectDatabaseQuery.SchemaChange" />
+    <exclude name="WordPress.VIP.RestrictedFunctions.switch_to_blog_switch_to_blog" />
     <exclude name="WordPress.WhiteSpace.CastStructureSpacing.NoSpaceBeforeOpenParenthesis" />
     <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.BlankLineAfterEnd" />
     <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceAfterCloseParenthesis" />


### PR DESCRIPTION
We need a database migration strategy that can fulfil all of these needs:

- It can create new tables upon plugin activation for the first time time
- It can create new columns, delete columns, rename columns, and modify columns, upon plugin update, in a deterministic way, with good testing of the results
- It can modify the data within the database using update queries, upon plugin update, in a deterministic way, with good testing of the results
- It can reverse those operations in case of emergency, and to allow rollback of plugin versions

Using `dbDelta` was ruled out, as it can only create and modify columns, but it can't delete them or rename them, nor does it support migrations that aren't related to schema.

This pull request does all of that, (except for the update part, which is a TODO comment for now). Ideally, I would like to have included testing, but I did not get around to finishing that.