### PR TITLE
Settings page

### DIFF
--- a/dt-core/admin/config-site-defaults.php
+++ b/dt-core/admin/config-site-defaults.php
@@ -85,7 +85,7 @@ function dt_get_option( string $name )
         case 'dt_site_options':
             $site_options = dt_get_site_options_defaults();
             
-            if( !get_option( 'dt_site_options' ) ) { // options doen't exist, create new.
+            if( !get_option( 'dt_site_options' ) ) { // options doesn't exist, create new.
                 $add = add_option( 'dt_site_options', $site_options, '', true );
                 if( !$add ) {
                     return new WP_Error( 'failed_add_site_option', 'Site option dt_site_options was not able to be created' );

--- a/dt-users/users-endpoints.php
+++ b/dt-users/users-endpoints.php
@@ -35,18 +35,12 @@ class Disciple_Tools_Users_Endpoints
         );
         
         register_rest_route(
-            $this->namespace, '/users/change_notification_preference', [
+            $this->namespace, '/users/switch_preference', [
                 'methods'  => WP_REST_Server::CREATABLE,
-                'callback' => [ $this, 'change_notification_preference' ],
+                'callback' => [ $this, 'switch_preference' ],
             ]
         );
     
-        register_rest_route(
-            $this->namespace, '/users/change_availability', [
-                'methods'  => WP_REST_Server::CREATABLE,
-                'callback' => [ $this, 'change_availability' ],
-            ]
-        );
     }
     
     /**
@@ -71,12 +65,12 @@ class Disciple_Tools_Users_Endpoints
      *
      * @return array|\WP_Error
      */
-    public function change_notification_preference( WP_REST_Request $request )
+    public function switch_preference( WP_REST_Request $request )
     {
         $params = $request->get_params();
         $user_id = get_current_user_id();
         if( isset( $params[ 'preference_key' ] ) ) {
-            $result = Disciple_Tools_Users::change_notification_preference( $user_id, $params[ 'preference_key' ] );
+            $result = Disciple_Tools_Users::switch_preference( $user_id, $params[ 'preference_key' ] );
             if( $result[ "status" ] ) {
                 return $result[ "response" ];
             } else {
@@ -84,22 +78,6 @@ class Disciple_Tools_Users_Endpoints
             }
         } else {
             return new WP_Error( "preference_error", "Please provide a valid preference to change for user", [ 'status', 400 ] );
-        }
-    }
-    
-    /**
-     * @param \WP_REST_Request $request
-     *
-     * @return array|\WP_Error
-     */
-    public function change_availability( WP_REST_Request $request )
-    {
-        $user_id = get_current_user_id();
-        $result = Disciple_Tools_Users::change_availability( $user_id );
-        if( $result[ "status" ] ) {
-            return $result[ "response" ];
-        } else {
-            return new WP_Error( "change_availability_error", $result[ "message" ], [ 'status', 400 ] );
         }
     }
     

--- a/dt-users/users-template.php
+++ b/dt-users/users-template.php
@@ -248,7 +248,7 @@ function dt_get_user_locations_list( int $user_id )
     // get connected location ids to user
     $location_ids = $wpdb->get_col(
         $wpdb->prepare(
-            "SELECT p2p_from as location_id FROM  $wpdb->p2p WHERE p2p_to = '%d' AND p2p_type = 'team_member_locations';", $user_id )
+        "SELECT p2p_from as location_id FROM  $wpdb->p2p WHERE p2p_to = '%d' AND p2p_type = 'team_member_locations';", $user_id )
     );
     
     // check if null return

--- a/dt-users/users-template.php
+++ b/dt-users/users-template.php
@@ -142,99 +142,6 @@ function dt_get_team_contacts( $user_id )
     return $user_connections;
 }
 
-/**
- * Get user notification options
- *
- * @param int|null $user_id
- *
- * @return array|WP_Error
- */
-function dt_get_user_notification_options( int $user_id = null )
-{
-    if( is_null( $user_id ) ) {
-        $user_id = get_current_user_id();
-    }
-    
-    $check = dt_user_notification_options_check( $user_id );
-    if( is_wp_error( $check ) ) {
-        return $check;
-    }
-    
-    return get_user_meta( $user_id, 'dt_notification_options', true );
-}
-
-/**
- * Check for existence of user notification options
- *
- * @param int $user_id
- *
- * @return bool|WP_Error
- */
-function dt_user_notification_options_check( int $user_id ): bool
-{
-    
-    // check existence of options for user
-    if( !get_user_meta( $user_id, 'dt_notification_options' ) ) {
-        
-        // if they don't exist create them
-        $site_options = dt_get_option( 'dt_site_options' );
-        $notifications_default = $site_options[ 'user_notifications' ];
-        $result = add_user_meta( $user_id, 'dt_notification_options', $notifications_default, true );
-        if( !$result ) {
-            return new WP_Error( 'user_option_check_fail', 'Failed to create options for user_id. Check id.' ); // return false if fail to create options for user
-        }
-        
-        return true; // return true, options now exist
-    }
-    
-    return true; // return true, options exist
-}
-
-/**
- * Get user availability options
- *
- * @param int|null $user_id
- *
- * @return array|WP_Error
- */
-function dt_get_user_option_availability( int $user_id = null )
-{
-    if( is_null( $user_id ) ) {
-        $user_id = get_current_user_id();
-    }
-    
-    $check = dt_user_availability_option_check( $user_id );
-    if( is_wp_error( $check ) ) {
-        return $check;
-    }
-    
-    return get_user_meta( $user_id, 'dt_availability', true );
-}
-
-/**
- * Check for existence of user availability option
- *
- * @param int $user_id
- *
- * @return bool|WP_Error
- */
-function dt_user_availability_option_check( int $user_id )
-{
-    
-    // check existence of options for user
-    if( !get_user_meta( $user_id, 'dt_availability' ) ) {
-        
-        // if they don't exist create them
-        $result = add_user_meta( $user_id, 'dt_availability', false, true );
-        if( !$result ) {
-            return new WP_Error( 'add_user_availability_fail', 'Failed to create meta record dt_availability.' ); // return false if fail to create options for user
-        }
-        
-        return true; // return true, options now exist
-    }
-    
-    return true; // return true, options exist
-}
 
 /**
  * Gets the current site defaults defined in the notifications config section in wp-admin
@@ -341,7 +248,7 @@ function dt_get_user_locations_list( int $user_id )
     // get connected location ids to user
     $location_ids = $wpdb->get_col(
         $wpdb->prepare(
-        "SELECT p2p_from as location_id FROM  $wpdb->p2p WHERE p2p_to = '%d' AND p2p_type = 'team_member_locations';", $user_id )
+            "SELECT p2p_from as location_id FROM  $wpdb->p2p WHERE p2p_to = '%d' AND p2p_type = 'team_member_locations';", $user_id )
     );
     
     // check if null return

--- a/dt-users/users.php
+++ b/dt-users/users.php
@@ -81,8 +81,8 @@ class Disciple_Tools_Users
 
         $value = get_user_meta( $user_id, $preference_key, true );
     
-        if( empty($value) ) {
-            $status = update_metadata( 'user', $user_id, $preference_key, true);
+        if( empty( $value ) ) {
+            $status = update_metadata( 'user', $user_id, $preference_key, true );
             if( $status ) {
                 return [
                     'status'   => true,

--- a/dt-users/users.php
+++ b/dt-users/users.php
@@ -67,77 +67,46 @@ class Disciple_Tools_Users
 
         return $list;
     }
-
+    
     /**
+     * Switch user preference for notifications and availability meta fields.
+     *
      * @param int    $user_id
      * @param string $preference_key
      *
      * @return array
      */
-    public static function change_notification_preference( int $user_id, string $preference_key )
+    public static function switch_preference( int $user_id, string $preference_key )
     {
 
-        $user_notifications = dt_get_user_notification_options( $user_id );
-        if( is_wp_error( $user_notifications ) ) {
-            return [
-                'status'  => false,
-                'message' => $user_notifications->get_error_message(),
-            ];
-        }
-
-        foreach( $user_notifications as $key => $value ) {
-            if( $key == $preference_key ) {
-                $value === true ? $user_notifications[ $key ] = false : $user_notifications[ $key ] = true;
+        $value = get_user_meta( $user_id, $preference_key, true );
+    
+        if( empty($value) ) {
+            $status = update_metadata( 'user', $user_id, $preference_key, true);
+            if( $status ) {
+                return [
+                    'status'   => true,
+                    'response' => $status,
+                ];
+            } else {
+                return [
+                    'status'  => false,
+                    'message' => 'Unable to update_user_option '.$preference_key.' to true.',
+                ];
+            }
+        } else {
+            $status = update_metadata( 'user', $user_id, $preference_key, false );
+            if( $status ) {
+                return [
+                    'status'   => true,
+                    'response' => $status,
+                ];
+            } else {
+                return [
+                    'status'  => false,
+                    'message' => 'Unable to update_user_option '.$preference_key.' to false.',
+                ];
             }
         }
-
-        $update = update_user_meta( $user_id, 'dt_notification_options', $user_notifications );
-
-        if( $update ) {
-            return [
-                'status'   => true,
-                'response' => 'success',
-            ];
-        } else {
-            return [
-                'status'  => false,
-                'message' => 'Unable to update_user_option while updating user notification preferences.',
-            ];
-        }
     }
-
-    /**
-     * @param int $user_id
-     *
-     * @return array
-     */
-    public static function change_availability( int $user_id )
-    {
-
-        $user_availability = dt_get_user_option_availability( $user_id );
-        if( is_wp_error( $user_availability ) ) {
-            return [
-                'status'  => false,
-                'message' => 'Failed to get user availability option from db.',
-            ];
-        };
-
-        $user_availability == true ? $user_availability = false : $user_availability = true;
-
-        // @codingStandardsIgnoreLine  Note: VIP coding standards errors on the use of update_user_meta
-        $update = update_user_meta( $user_id, 'dt_availability', $user_availability );
-
-        if( $update ) {
-            return [
-                'status'   => true,
-                'response' => 'success',
-            ];
-        } else {
-            return [
-                'status'  => false,
-                'message' => 'Unable to update user dt_availability option.',
-            ];
-        }
-    }
-
 }


### PR DESCRIPTION
Major simplification of the preferences saving logic. I abandoned the pattern of saving the preference into a single key with an array. It required to much house keeping with regular updating from the users. Instead I moved each preference out to its own key in the meta table. This cleared up an enormous amount of housekeeping code and should produce a more durable format.

https://github.com/DiscipleTools/disciple-tools-theme/pull/61