### PR TITLE
Relicense to GPLv2 or later

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,32 @@
+Disciple.Tools plugin
+
+Copyright (C) 2017 by Chris W and other contributors
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+This program incoporates these works:
+
+- "members" or "multi-role" by Justin Tadlock (and/or contributors), licensed
+under GPLv2 or later
+- Modified version of Plugin 'Three Column Screen Layout', by Chad Hovell
+(and/or contributors), licensed under GPLv2 or later
+- Posts 2 Posts, by scribu, ciobi (and/or contributors), licensed under GPLv2
+or later
+
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 

--- a/disciple-tools.php
+++ b/disciple-tools.php
@@ -14,7 +14,7 @@
  * @package Disciple_Tools
  * @author  Chasm Solutions <chasm.crew@chasm.solutions>
  * @link    https://github.com/DiscipleTools
- * @license GPL-2.0 and later
+ * @license GPL-2.0 or later
  *          https://www.gnu.org/licenses/gpl-2.0.html
  * @version 1.0.0
  *


### PR DESCRIPTION
Based on the Git history of this project, this project only has three authors so far:

- @ChrisChasm 
- @corsacca 
- @burntsun

So it's my determination that these are the only copyright holders (ignoring the included libraries).

Before these gets merged in, could each user post a comment here saying this:

> I agree to license all my contributions to disciple-tools, disciple-tools-theme, disciple-tools-demo-plugin, (as well as any other repos included in DiscipleTools GitHub organization), to GPLv2 or later, as published by the Free Software Foundation.

For additional record keeping, could we send each other an email that says the same thing?

Thanks.